### PR TITLE
Add clarification on the two licenses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@
 
 This repository holds the source files that will be (soon) served on
 http://blog.janusgraph.org .
+
+## License
+
+This repo uses a combination of [Apache 2.0](APACHE-2.0.txt) and
+[CC-BY-4.0](CC-BY-4.0.txt); see [`LICENSE.txt`](LICENSE.txt) for details.


### PR DESCRIPTION
This will match the description in other repos, such as docs.janusgraph.org .