### PR TITLE
Fix Apache license copyright template.

### DIFF
--- a/APACHE-2.0.txt
+++ b/APACHE-2.0.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2012-2013 Aurelius LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -210,7 +210,7 @@ For convenience, copies of APACHE-2.0 and CC-BY-4.0 are included verbatim below.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2012-2013 Aurelius LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This line is not supposed to be a specific copyright holder or year;
it's a template line, and should have been transferred as-is from the
Apache 2.0 license, which can be found at
https://www.apache.org/licenses/LICENSE-2.0.txt